### PR TITLE
add option to pass access token in a header

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ apig-test \
   --method='GET' \
   --params='{}' \
   --additional-params='{}' \
+  --access-token-header='cognito-access-token' \
   --body='{}'
 ```
 
@@ -70,6 +71,9 @@ This command takes the following options:
 
 - `additional-params`
   Any additional params (including the querystring) as a JSON string. Defaults to `'{}'`.
+
+- `access-token-header`
+  Header field on which to pass the access token.
 
 - `body`
   The request body as a JSON string. Defaults to `'{}'`.

--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ function getCredentials(userTokens, callback) {
   console.log("Getting temporary credentials");
 
   var logins = {};
-  const { idToken, accessToken } = userTokens;
+  const idToken = userTokens.idToken;
+  const accessToken = userTokens.accessToken;
 
   logins[
     "cognito-idp." + argv.cognitoRegion + ".amazonaws.com/" + argv.userPoolId
@@ -178,7 +179,7 @@ function makeRequest(userTokens) {
       console.dir({
         status: result.status,
         statusText: result.statusText,
-        data: JSON.stringify(result.data)
+        data: result.data
       });
     })
     .catch(function(result) {
@@ -186,7 +187,7 @@ function makeRequest(userTokens) {
         console.dir({
           status: result.response.status,
           statusText: result.response.statusText,
-          data: JSON.stringify(result.response.data)
+          data: result.response.data
         });
       } else {
         console.log(result.message);


### PR DESCRIPTION
  This adds an option 'access-token-header' to allow the user to set a HTTP header on which to pass the access token along with the request. This is required when using a custom authorizer as described here: https://aws.amazon.com/blogs/mobile/integrating-amazon-cognito-user-pools-with-api-gateway/. 