### PR TITLE
Optionally show response payload with debug command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ apig-test \
   --additional-params='{}' \
   --access-token-header='cognito-access-token' \
   --body='{}'
+  --debug
 ```
 
 If you have it locally installed:
@@ -70,7 +71,7 @@ This command takes the following options:
 
 - `api-gateway-region`
   The API Gateway region. Defaults to `us-east-1`.
-  
+
 - `api-key`
   The API key if required by the method. Defaults to none.
 
@@ -91,6 +92,9 @@ This command takes the following options:
 
 - `body`
   The request body as a JSON string. Defaults to `'{}'`.
+
+- `debug`
+    Additional debug output for response payload and errors.
 
 For additional documentation on the format for `params` and `additional-params`; refer to the generic [API Gateway Client][apiGClient] docs.
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,12 @@ var argv = require("yargs")
   .option("access-token-header", {
     describe: "Header to use to pass access token with request"
   })
+  .option("debug",{
+    describe: "Additional debug output for response and errors",
+    default: false
+  })
   .help("h")
+  .alias("d", "debug")
   .alias("h", "help")
   .alias("v", "version")
   .version(packageJson.version)
@@ -180,6 +185,10 @@ function makeRequest(userTokens) {
         status: result.status,
         statusText: result.statusText,
         data: result.data
+      },{
+          showHidden:argv.debug,
+          depth:argv.debug ? null : 2,
+          colors:argv.debug
       });
     })
     .catch(function(result) {
@@ -188,7 +197,11 @@ function makeRequest(userTokens) {
           status: result.response.status,
           statusText: result.response.statusText,
           data: result.response.data
-        });
+        },{
+          showHidden:argv.debug,
+          depth:argv.debug ? null : 2,
+          colors:argv.debug
+      });
       } else {
         console.log(result.message);
       }


### PR DESCRIPTION
Fix for bug #8 to optionally show response payload with --debug command line parameter