### PR TITLE
Add option to test without using IAM credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This command takes the following options:
 
 - `api-gateway-region`
   The API Gateway region. Defaults to `us-east-1`.
-  
+
 - `api-key`
   The API key if required by the method. Defaults to none.
 
@@ -91,6 +91,9 @@ This command takes the following options:
 
 - `body`
   The request body as a JSON string. Defaults to `'{}'`.
+
+- `anonymous`
+  Perform action anonymously, without IAM credentials.
 
 For additional documentation on the format for `params` and `additional-params`; refer to the generic [API Gateway Client][apiGClient] docs.
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ var argv = require("yargs")
     describe: "API request additional params",
     default: "{}"
   })
+  .option("anonymous", {
+    describe: "Perform action without IAM credentials",
+    demandOption: false
+  })
   .option("body", {
     describe: "API request body",
     default: "{}"
@@ -195,6 +199,10 @@ function makeRequest(userTokens) {
     });
 }
 
-authenticate(function(tokens) {
-  getCredentials(tokens, makeRequest);
-});
+if (argv.anonymous) {
+  makeRequest(null)
+} else {
+  authenticate(function(tokens) {
+    getCredentials(tokens, makeRequest);
+  });
+}


### PR DESCRIPTION
Added option to test API Gateway endpoint without IAM authorization to allow for testing of APIs which exhibit different behaviors depending on whether user is authorized or anonymous.