### PR TITLE
Allow use of yargs .config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ $ npx aws-api-gateway-cli-test --options
 
 This command takes the following options:
 
+- `config`
+  Read parameters from a file.  File must be valid JSON and end in a .json extension.  Command line parameters will override the same config file parameter.
+
 - `username`
   The username of the Cognito User Pool user.
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ global.navigator = function() {
 };
 
 var argv = require("yargs")
+  .config()
   .option("username", {
     describe: "Username of the user",
     demandOption: true,


### PR DESCRIPTION
Hi, been using this a lot recently, super convenient, hoped you might incorporate this little tweak to make it even more so!

Included the .config() option in the yargs parameter handling in order to allow parameters to be read from a config file specified with the --config command line option i.e. `--config test.json` rather than everything having to be entered on the command line every time.