### PR TITLE
Make Identity Pool / IAM authorization optional, fall back to JWT authorization if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This command takes the following options:
   The Cognito User Pool region. Defaults to `us-east-1`.
 
 - `identity-pool-id`
-  The Cognito Identity Pool Id.
+  Optional Cognito Identity Pool Id.  If provided, attempt to use IAM authorisation, else fall back to JWT authorisation.
 
 - `invoke-url`
   The API Gateway root endpoint.


### PR DESCRIPTION
Hiya, another unsolicited pull request, sorry! Super useful test utility, but I'm doing a bunch of JWT authorization based stuff.

Originally went with a separate makeJWTRequest() function and bypassed getCredentials altogether approach, however figured this approach was less duplication.

Only other thought was potentially pulling out additionalParams to a global, so I could handle the Authorization header in the getCredentials() bypass and avoid doing another argv.identityPoolId check in makeRequest(), which would make things a little cleaner, but didn't implement.  Not sure on your philosophy on globals :)